### PR TITLE
Propagate demo2 bug fixes.

### DIFF
--- a/nerfbridge/method_configs.py
+++ b/nerfbridge/method_configs.py
@@ -115,7 +115,7 @@ DepthNerfBridgeDemo = MethodSpecification(
                 pixel_sampler=PairPixelSamplerConfig(),
                 dataparser=ROSDataParserConfig(
                     scale_factor=0.1,
-                    aabb_scale=2.0,
+                    aabb_scale=4.0,
                 ),
                 train_num_rays_per_batch=4096,
                 eval_num_rays_per_batch=4096,
@@ -124,8 +124,8 @@ DepthNerfBridgeDemo = MethodSpecification(
                     optimizer=AdamOptimizerConfig(lr=6e-4, eps=1e-8, weight_decay=1e-2),
                 ),
                 use_compressed_rgb=True,
-                topic_slop=0.075,
-                slam_method="mocap",
+                topic_slop=0.3,
+                slam_method="cuvslam",
                 data_update_freq=5.0,
                 num_training_images=500
             ),
@@ -175,7 +175,7 @@ NerfBridgeDemo = MethodSpecification(
                     optimizer=AdamOptimizerConfig(lr=6e-4, eps=1e-8, weight_decay=1e-2),
                 ),
                 use_compressed_rgb=True,
-                topic_slop=0.08,
+                topic_slop=0.3,
                 slam_method="mocap",
                 data_update_freq=5.0,
                 num_training_images=500

--- a/nerfbridge/method_configs.py
+++ b/nerfbridge/method_configs.py
@@ -108,14 +108,14 @@ DepthNerfBridgeDemo = MethodSpecification(
         max_num_iterations=30000,
         mixed_precision=True,
         draw_training_images=True,
-        msg_timeout=300.0,
+        msg_timeout=3000.0,
         pipeline=VanillaPipelineConfig(
             datamanager=ROSDataManagerConfig(
                 _target=ROSDataManager[ROSDepthDataset],
                 pixel_sampler=PairPixelSamplerConfig(),
                 dataparser=ROSDataParserConfig(
-                    scale_factor=0.1,
-                    aabb_scale=4.0,
+                    scale_factor=0.15,
+                    aabb_scale=2.0,
                 ),
                 train_num_rays_per_batch=4096,
                 eval_num_rays_per_batch=4096,
@@ -125,13 +125,13 @@ DepthNerfBridgeDemo = MethodSpecification(
                 ),
                 use_compressed_rgb=True,
                 topic_slop=0.3,
-                slam_method="cuvslam",
-                data_update_freq=5.0,
+                slam_method="mocap",
+                data_update_freq=8.0,
                 num_training_images=500
             ),
             model=DepthNerfactoModelConfig(
                 eval_num_rays_per_chunk=1 << 15,
-                depth_loss_mult=1.0,
+                depth_loss_mult=0.1,
                 depth_sigma=0.07,
                 depth_loss_type=DepthLossType.DS_NERF
             ),
@@ -160,12 +160,13 @@ NerfBridgeDemo = MethodSpecification(
         max_num_iterations=30000,
         mixed_precision=True,
         draw_training_images=True,
+        msg_timeout=1000.0,
         pipeline=VanillaPipelineConfig(
             datamanager=ROSDataManagerConfig(
                 _target=ROSDataManager[ROSDataset],
                 pixel_sampler=PairPixelSamplerConfig(),
                 dataparser=ROSDataParserConfig(
-                    scale_factor=0.1,
+                    scale_factor=0.15,
                     aabb_scale=2.0,
                 ),
                 train_num_rays_per_batch=4096,
@@ -177,7 +178,7 @@ NerfBridgeDemo = MethodSpecification(
                 use_compressed_rgb=True,
                 topic_slop=0.3,
                 slam_method="mocap",
-                data_update_freq=5.0,
+                data_update_freq=8.0,
                 num_training_images=500
             ),
             model=NerfactoModelConfig(

--- a/nerfbridge/method_configs.py
+++ b/nerfbridge/method_configs.py
@@ -8,7 +8,7 @@ NerfBridge Method Configs
 from __future__ import annotations
 
 from nerfstudio.cameras.camera_optimizers import CameraOptimizerConfig
-from nerfstudio.configs.base_config import LocalWriterConfig, ViewerConfig
+from nerfstudio.configs.base_config import ViewerConfig
 from nerfstudio.engine.optimizers import AdamOptimizerConfig
 from nerfstudio.models.nerfacto import NerfactoModelConfig
 from nerfstudio.models.depth_nerfacto import DepthNerfactoModelConfig
@@ -98,105 +98,4 @@ RosDepthNerfacto = MethodSpecification(
         vis="viewer",
     ),
     description="Run NerfBridge with the DepthNerfacto model, and train with streamed RGB and depth images.",
-)
-
-DepthNerfBridgeDemo = MethodSpecification(
-    config=ROSTrainerConfig(
-        method_name="depth-nerfbridge-demo",
-        steps_per_eval_batch=500,
-        steps_per_save=30000,
-        max_num_iterations=30000,
-        mixed_precision=True,
-        draw_training_images=True,
-        msg_timeout=3000.0,
-        pipeline=VanillaPipelineConfig(
-            datamanager=ROSDataManagerConfig(
-                _target=ROSDataManager[ROSDepthDataset],
-                pixel_sampler=PairPixelSamplerConfig(),
-                dataparser=ROSDataParserConfig(
-                    scale_factor=0.15,
-                    aabb_scale=2.0,
-                ),
-                train_num_rays_per_batch=4096,
-                eval_num_rays_per_batch=4096,
-                camera_optimizer=CameraOptimizerConfig(
-                    mode="SO3xR3",
-                    optimizer=AdamOptimizerConfig(lr=6e-4, eps=1e-8, weight_decay=1e-2),
-                ),
-                use_compressed_rgb=True,
-                topic_slop=0.3,
-                slam_method="mocap",
-                data_update_freq=8.0,
-                num_training_images=500
-            ),
-            model=DepthNerfactoModelConfig(
-                eval_num_rays_per_chunk=1 << 15,
-                depth_loss_mult=0.1,
-                depth_sigma=0.07,
-                depth_loss_type=DepthLossType.DS_NERF
-            ),
-        ),
-        optimizers={
-            "proposal_networks": {
-                "optimizer": AdamOptimizerConfig(lr=1e-2, eps=1e-15),
-                "scheduler": None,
-            },
-            "fields": {
-                "optimizer": AdamOptimizerConfig(lr=1e-2, eps=1e-15),
-                "scheduler": None,
-            },
-        },
-        viewer=ViewerConfig(num_rays_per_chunk=20000),
-        vis="viewer",
-    ),
-    description="Run NerfBridge for live demos in MSL Flightroom.",
-)
-
-NerfBridgeDemo = MethodSpecification(
-    config=ROSTrainerConfig(
-        method_name="nerfbridge-demo",
-        steps_per_eval_batch=500,
-        steps_per_save=30000,
-        max_num_iterations=30000,
-        mixed_precision=True,
-        draw_training_images=True,
-        msg_timeout=1000.0,
-        pipeline=VanillaPipelineConfig(
-            datamanager=ROSDataManagerConfig(
-                _target=ROSDataManager[ROSDataset],
-                pixel_sampler=PairPixelSamplerConfig(),
-                dataparser=ROSDataParserConfig(
-                    scale_factor=0.15,
-                    aabb_scale=2.0,
-                ),
-                train_num_rays_per_batch=4096,
-                eval_num_rays_per_batch=4096,
-                camera_optimizer=CameraOptimizerConfig(
-                    mode="SO3xR3",
-                    optimizer=AdamOptimizerConfig(lr=6e-4, eps=1e-8, weight_decay=1e-2),
-                ),
-                use_compressed_rgb=True,
-                topic_slop=0.3,
-                slam_method="mocap",
-                data_update_freq=8.0,
-                num_training_images=500
-            ),
-            model=NerfactoModelConfig(
-                eval_num_rays_per_chunk=1 << 15,
-            ),
-        ),
-        optimizers={
-            "proposal_networks": {
-                "optimizer": AdamOptimizerConfig(lr=1e-2, eps=1e-15),
-                "scheduler": None,
-            },
-            "fields": {
-                "optimizer": AdamOptimizerConfig(lr=1e-2, eps=1e-15),
-                "scheduler": None,
-            },
-        },
-        viewer=ViewerConfig(num_rays_per_chunk=20000),
-        vis="viewer",
-    ),
-    description="Run NerfBridge for live demos in MSL Flightroom.",
 )

--- a/nerfbridge/method_configs.py
+++ b/nerfbridge/method_configs.py
@@ -8,7 +8,7 @@ NerfBridge Method Configs
 from __future__ import annotations
 
 from nerfstudio.cameras.camera_optimizers import CameraOptimizerConfig
-from nerfstudio.configs.base_config import ViewerConfig
+from nerfstudio.configs.base_config import LocalWriterConfig, ViewerConfig
 from nerfstudio.engine.optimizers import AdamOptimizerConfig
 from nerfstudio.models.nerfacto import NerfactoModelConfig
 from nerfstudio.models.depth_nerfacto import DepthNerfactoModelConfig
@@ -100,14 +100,15 @@ RosDepthNerfacto = MethodSpecification(
     description="Run NerfBridge with the DepthNerfacto model, and train with streamed RGB and depth images.",
 )
 
-NerfBridgeDemo = MethodSpecification(
+DepthNerfBridgeDemo = MethodSpecification(
     config=ROSTrainerConfig(
-        method_name="nerfbridge-demo",
+        method_name="depth-nerfbridge-demo",
         steps_per_eval_batch=500,
         steps_per_save=30000,
         max_num_iterations=30000,
         mixed_precision=True,
         draw_training_images=True,
+        msg_timeout=300.0,
         pipeline=VanillaPipelineConfig(
             datamanager=ROSDataManagerConfig(
                 _target=ROSDataManager[ROSDepthDataset],
@@ -123,16 +124,64 @@ NerfBridgeDemo = MethodSpecification(
                     optimizer=AdamOptimizerConfig(lr=6e-4, eps=1e-8, weight_decay=1e-2),
                 ),
                 use_compressed_rgb=True,
-                topic_slop=0.02,
+                topic_slop=0.075,
                 slam_method="mocap",
-                data_update_freq=3.0,
-                num_training_images=300
+                data_update_freq=5.0,
+                num_training_images=500
             ),
             model=DepthNerfactoModelConfig(
                 eval_num_rays_per_chunk=1 << 15,
                 depth_loss_mult=1.0,
-                depth_sigma=0.01,
-                depth_loss_type=DepthLossType.URF
+                depth_sigma=0.07,
+                depth_loss_type=DepthLossType.DS_NERF
+            ),
+        ),
+        optimizers={
+            "proposal_networks": {
+                "optimizer": AdamOptimizerConfig(lr=1e-2, eps=1e-15),
+                "scheduler": None,
+            },
+            "fields": {
+                "optimizer": AdamOptimizerConfig(lr=1e-2, eps=1e-15),
+                "scheduler": None,
+            },
+        },
+        viewer=ViewerConfig(num_rays_per_chunk=20000),
+        vis="viewer",
+    ),
+    description="Run NerfBridge for live demos in MSL Flightroom.",
+)
+
+NerfBridgeDemo = MethodSpecification(
+    config=ROSTrainerConfig(
+        method_name="nerfbridge-demo",
+        steps_per_eval_batch=500,
+        steps_per_save=30000,
+        max_num_iterations=30000,
+        mixed_precision=True,
+        draw_training_images=True,
+        pipeline=VanillaPipelineConfig(
+            datamanager=ROSDataManagerConfig(
+                _target=ROSDataManager[ROSDataset],
+                pixel_sampler=PairPixelSamplerConfig(),
+                dataparser=ROSDataParserConfig(
+                    scale_factor=0.1,
+                    aabb_scale=2.0,
+                ),
+                train_num_rays_per_batch=4096,
+                eval_num_rays_per_batch=4096,
+                camera_optimizer=CameraOptimizerConfig(
+                    mode="SO3xR3",
+                    optimizer=AdamOptimizerConfig(lr=6e-4, eps=1e-8, weight_decay=1e-2),
+                ),
+                use_compressed_rgb=True,
+                topic_slop=0.08,
+                slam_method="mocap",
+                data_update_freq=5.0,
+                num_training_images=500
+            ),
+            model=NerfactoModelConfig(
+                eval_num_rays_per_chunk=1 << 15,
             ),
         ),
         optimizers={

--- a/nerfbridge/pose_utils.py
+++ b/nerfbridge/pose_utils.py
@@ -62,6 +62,6 @@ def mocap_to_nerfstudio(T_mocap: torch.Tensor):
     Converts a homogenous matrix 4x4 from the coordinate system used in mocap
     to the Nerfstudio camera coordinate system 3x4 matrix.
     """
-    T_ns = T_mocap[[1, 2, 0, 3], :]
+    T_ns = T_mocap[:, [1, 2, 0, 3]]
     T_ns[:, [0, 2]] *= -1
     return T_ns[:3, :]

--- a/nerfbridge/pose_utils.py
+++ b/nerfbridge/pose_utils.py
@@ -2,8 +2,6 @@ import torch
 from geometry_msgs.msg import Pose
 from scipy.spatial.transform import Rotation
 
-import pdb
-
 """
 Utilities for converting ROS2 pose messages to torch tensors, and for converting
 poses expressed in other coordinate systems to the Nerfstudio coordinate sytem.
@@ -56,6 +54,7 @@ def orbslam3_to_nerfstudio(T_orbslam3: torch.Tensor):
     T_ns[:, [1, 2]] *= -1
     T_ns[2, :] *= -1
     return T_ns[:3, :]
+
 
 def mocap_to_nerfstudio(T_mocap: torch.Tensor):
     """

--- a/nerfbridge/ros_dataloader.py
+++ b/nerfbridge/ros_dataloader.py
@@ -19,7 +19,6 @@ from torch.utils.data.dataloader import DataLoader
 
 import nerfbridge.pose_utils as pose_utils
 from nerfbridge.ros_dataset import ROSDataset, ROSDepthDataset
-from nerfstudio.utils import writer
 
 import rclpy
 from sensor_msgs.msg import Image, CompressedImage
@@ -28,8 +27,6 @@ from std_msgs.msg import String
 from nav_msgs.msg import Odometry
 from message_filters import ApproximateTimeSynchronizer, TimeSynchronizer, Subscriber
 from cv_bridge import CvBridge
-
-import pdb
 
 CONSOLE = Console(width=120)
 

--- a/nerfbridge/ros_dataloader.py
+++ b/nerfbridge/ros_dataloader.py
@@ -219,11 +219,12 @@ class ROSDataloader(DataLoader):
         # Load the image message directly into the torch
         if self.use_compressed_rgb:
             im_cv = self.bridge.compressed_imgmsg_to_cv2(image)
+            im_tensor = torch.from_numpy(im_cv).to(dtype=torch.float32) / 255.0
+            im_tensor = torch.flip(im_tensor, [-1])
         else:
             im_cv = self.bridge.imgmsg_to_cv2(image, image.encoding)
+            im_tensor = torch.from_numpy(im_cv).to(dtype=torch.float32) / 255.0
 
-        im_tensor = torch.from_numpy(im_cv).to(dtype=torch.float32) / 255.0
-        im_tensor = torch.flip(im_tensor, [-1])
 
         # COPY the image data into the data tensor
         self.dataset.image_tensor[self.current_idx] = im_tensor

--- a/nerfbridge/ros_datamanager.py
+++ b/nerfbridge/ros_datamanager.py
@@ -7,8 +7,6 @@ from typing import Type, Dict, Tuple, Generic, cast, get_origin, get_args
 from typing_extensions import TypeVar
 from functools import cached_property
 from nerfstudio.utils.misc import get_orig_class
-from nerfstudio.utils import writer
-from nerfstudio.utils.writer import EventType
 
 from rich.console import Console
 
@@ -22,8 +20,6 @@ from nerfstudio.cameras.rays import RayBundle
 from nerfbridge.ros_dataset import ROSDataset
 from nerfbridge.ros_dataloader import ROSDataloader
 from nerfbridge.ros_dataparser import ROSDataParserConfig
-
-import pdb
 
 
 CONSOLE = Console(width=120)

--- a/nerfbridge/ros_datamanager.py
+++ b/nerfbridge/ros_datamanager.py
@@ -7,6 +7,8 @@ from typing import Type, Dict, Tuple, Generic, cast, get_origin, get_args
 from typing_extensions import TypeVar
 from functools import cached_property
 from nerfstudio.utils.misc import get_orig_class
+from nerfstudio.utils import writer
+from nerfstudio.utils.writer import EventType
 
 from rich.console import Console
 

--- a/nerfbridge/ros_trainer.py
+++ b/nerfbridge/ros_trainer.py
@@ -94,5 +94,7 @@ class ROSTrainer(Trainer):
                     camera_json = self.dataset.cameras.to_json(
                         camera_idx=idx, image=bgr, max_size=100
                     )
-                    self.viewer_state.viser_server.add_dataset_image(idx=f"{idx:06d}", json=camera_json)
+                    self.viewer_state.viser_server.add_dataset_image(
+                        idx=f"{idx:06d}", json=camera_json
+                    )
                     self.cameras_drawn.append(idx)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,4 @@ extraPaths = ["nerfbridge"]
 ros-nerfacto = 'nerfbridge.method_configs:RosNerfacto'
 ros-depth-nerfacto = 'nerfbridge.method_configs:RosDepthNerfacto'
 nerfbridge-demo = 'nerfbridge.method_configs:NerfBridgeDemo'
+depth-nerfbridge-demo = 'nerfbridge.method_configs:DepthNerfBridgeDemo'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,5 +15,3 @@ extraPaths = ["nerfbridge"]
 [project.entry-points.'nerfstudio.method_configs']
 ros-nerfacto = 'nerfbridge.method_configs:RosNerfacto'
 ros-depth-nerfacto = 'nerfbridge.method_configs:RosDepthNerfacto'
-nerfbridge-demo = 'nerfbridge.method_configs:NerfBridgeDemo'
-depth-nerfbridge-demo = 'nerfbridge.method_configs:DepthNerfBridgeDemo'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "nerfbridge"
 version = "0.1"
 
 dependencies = [
-	"nerfstudio==0.3.3"
+	"nerfstudio==0.3.4"
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,4 @@ extraPaths = ["nerfbridge"]
 [project.entry-points.'nerfstudio.method_configs']
 ros-nerfacto = 'nerfbridge.method_configs:RosNerfacto'
 ros-depth-nerfacto = 'nerfbridge.method_configs:RosDepthNerfacto'
+nerfbridge-demo = 'nerfbridge.method_configs:NerfBridgeDemo'


### PR DESCRIPTION
Fixed a number of issues that came up when running in person demos.

- Flipped RGB Channels
- Incorrect array slicing
- Longer queues for image processing in callbacks

Added some extra features:

- Dataloader health status topic
- Upgrade nerfstudio version